### PR TITLE
Add Samsung SCH-B311V (Verizon Wireless Prepaid)

### DIFF
--- a/sp.xml
+++ b/sp.xml
@@ -96,6 +96,7 @@
 <sp name="Samsung SCH-B259" key="5903365113726913"></sp>
 <sp name="Samsung SCH-B279" key="5903365113726913"></sp>
 <sp name="Samsung SCH-B309" key="5903365113726913"></sp>
+<sp name="Samsung SCH-B311V" key="2013091220140410"></sp>
 <sp name="Samsung SCH-E159" key="6905110834560250"></sp>
 <sp name="Samsung SCH-E170" key="9080012010807047"></sp>
 <sp name="Samsung SCH-E250" key="D5D3C920C2D1C5CC"></sp>


### PR DESCRIPTION
Password found from here: https://forum.gsmhosting.com/vbb/f770/need-16-digit-password-samung-gusto-3-b311v-1821930/index2.html#post10435916